### PR TITLE
262 Mocked response throws when sent twice

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -426,8 +426,8 @@ function createResponse(options) {
      */
     mockResponse.end = function() {
         if (_endCalled) {
-            // Do not emit this event twice.
-            return;
+            // Emulate _http_outgoing ERR_STREAM_WRITE_AFTER_END error.
+            throw new Error('write after end');
         }
 
         mockResponse.finished = true;

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -637,6 +637,9 @@ function createResponse(options) {
      *   Set a particular header by name.
      */
     mockResponse.setHeader = function(name, value) {
+        if (mockResponse.headersSent) {
+            throw new Error('Cannot set headers after they are sent to the client');
+        }
         mockResponse._headers[name.toLowerCase()] = value;
         return value;
     };

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -512,6 +512,14 @@ describe('mockResponse', function () {
         expect(response.header).to.throw;
       });
 
+      it('should throw an error when called after they are sent', function() {
+        response.set({ name1: 'value1' });
+        response.send();
+
+        expect(function() {
+          response.set({ name2: 'value2' });
+        }).to.throw();
+      });
     });
 
     describe('.get()', function () {
@@ -1515,14 +1523,14 @@ describe('mockResponse', function () {
       });
 
       it('should return true, when Content-Length equals data size', function () {
-        response.send('data');
         response.header('Content-Length', '4');
+        response.send('data');
         expect(response._isDataLengthValid()).to.be.true;
       });
 
       it('should return false, when Content-Length does not equal data size', function () {
-        response.send('data');
         response.header('Content-Length', '5');
+        response.send('data');
         expect(response._isDataLengthValid()).to.be.false;
       });
 

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -657,6 +657,13 @@ describe('mockResponse', function () {
         expect(response.send({})).to.equal(response);
       });
 
+      it('throws when called twice', function() {
+        var response = mockResponse.createResponse();
+        response.send('Can not send response twice');
+        expect(function() {
+          response.send('This one should fail!');
+        }).to.throw();
+      });
     });
 
     // TODO: fix in 2.0; method should mimic Express Response.json()
@@ -1202,8 +1209,17 @@ describe('mockResponse', function () {
           }
         };
         response.end();
-        response.end();
+        expect(function() {
+          response.end();
+        }).to.throw();
         expect(emits).to.eql(1);
+      });
+
+      it('throws when called twice', function() {
+        response.end();
+        expect(function() {
+          response.end();
+        }).to.throw();
       });
 
       it('should set writableEnded to true', function () {


### PR DESCRIPTION
This Pull Request closes #262. It emulates Node.js `http` in two cases:
1. [.end()](https://github.com/nodejs/node/blob/v18.12.1/lib/_http_outgoing.js#L967) throws `Error [ERR_STREAM_WRITE_AFTER_END]: write after end` error when response is sent
2. [.setHeader()](https://github.com/nodejs/node/blob/v18.12.1/lib/_http_outgoing.js#L644) throws `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client` error when headers are sent