### PR TITLE
Fixed index.d.ts import of mocks from express to specific dir

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-import { Request, Response, CookieOptions } from 'express';
+import { Request, Response, CookieOptions } from './express/mock-express';
 
 declare module 'node-mocks-http' {
 


### PR DESCRIPTION
When using npm (v16.13 or greater) and using another library that imports `@types/express`, the imported mocked Request, Response, and Cookie options can be polluted - leading to undesirable outcomes, especially in TS projects. Qualifying the import to be more specific resolves this issue.