### PR TITLE
Request async iterator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 env:
   node: true
+  es2017: true
+
+parserOptions:
+  ecmaVersion: 2019
 
 rules:
   comma-dangle: 2
@@ -42,7 +46,10 @@ rules:
   no-sync: 2
   no-loop-func: 2
   no-labels: 2
-  no-unused-vars: 1
+  no-unused-vars:
+    - 1
+    - argsIgnorePattern: ^_
+      varsIgnorePattern: ^_
   no-script-url: 2
   no-proto: 2
   no-iterator: 2

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -60,7 +60,7 @@ function createRequest(options) {
     mockRequest.originalUrl = options.originalUrl || mockRequest.url;
     mockRequest.baseUrl = options.baseUrl || mockRequest.url;
     mockRequest.path = options.path ||
-        ((options.url ? url.parse(options.url).pathname : ''));
+        (options.url ? url.parse(options.url).pathname : '');
     mockRequest.params = options.params ? options.params : {};
     if (options.session) {
         mockRequest.session = options.session;

--- a/lib/mockRequest.js
+++ b/lib/mockRequest.js
@@ -540,6 +540,109 @@ function createRequest(options) {
         return subdomains.slice(offset);
     }());
 
+    /**
+     * Function: asyncIterator
+     *
+     *    Buffers data, error, end, and close events and yields them in order.
+     *    Unlike stream.Readable, this async iterator implementation will not exit
+     *    early on error or close.
+     */
+    mockRequest[Symbol.asyncIterator] = async function* asyncIterator() {
+        let ended = false;
+        let closed = false;
+        let error = null;
+        let chunks = [];
+        let resolvePromise = null;
+    
+        const promiseExecutor = resolve => {
+            resolvePromise = resolve;
+        };
+    
+        const promiseResolver = () => {
+            if (resolvePromise) {
+                resolvePromise();
+                resolvePromise = null;
+            }
+        };
+        const dataEventHandler = chunk => {
+            if (ended || closed || error) {
+                return;
+            }
+            chunks.push(chunk);
+            promiseResolver();
+        };
+        const endEventHandler = () => {
+            if (ended || closed || error) {
+                return;
+            }
+            ended = true;
+            promiseResolver();
+        };
+        const closeEventHandler = () => {
+            if (closed || error) {
+                return;
+            }
+            closed = true;
+            promiseResolver();
+        };
+        const errorEventHandler = err => {
+            if (closed || error) {
+                return;
+            }
+            error = err;
+            promiseResolver();
+        };
+    
+        mockRequest.on('data', dataEventHandler);
+        mockRequest.on('end', endEventHandler);
+        mockRequest.on('close', closeEventHandler);
+        mockRequest.on('error', errorEventHandler);
+
+        // Emit custom event after entering the loop.
+        setTimeout(() => {
+            this.emit('async_iterator');
+        });
+    
+        try {
+            for (;;) {
+                await new Promise(promiseExecutor);
+                let i = 0;
+                for (;;) {
+                    if (error) {
+                        throw error;
+                    }
+                    if (closed) {
+                        return;
+                    }
+                    
+                    const hasChunks = i < chunks.length;
+                    if (!hasChunks) {
+                        if (ended) {
+                            // End signaled. Bail.
+                            return;
+                        }
+                        // Wait for next push.
+                        break;
+                    }
+                    
+                    const chunk = chunks[i];
+                    chunks[i] = undefined;
+                    i += 1;
+                    yield chunk;
+                }
+                chunks.length = 0;
+            }
+        } finally {
+            chunks.length = 0;
+            error = null;
+
+            mockRequest.off('data', dataEventHandler);
+            mockRequest.off('end', endEventHandler);
+            mockRequest.off('close', closeEventHandler);
+            mockRequest.off('error', errorEventHandler);
+        }
+    };
+
     return mockRequest;
 }
 


### PR DESCRIPTION
Resolves issue https://github.com/eugef/node-mocks-http/issues/277

Implement the [async iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols) for mock request.

The request emits a new custom event `'async_iterator'` after a new async iterator is created. Async iterators are generally created lazily on demand. The async iterator will only yield data that is sent after it has been created since the request does not have an internal buffer (unlike stream.Readable). Without the new event it would be hard to know when exactly it is okay send data because you might sent it before the async iterator has been created. Check this [test case](https://github.com/eugef/node-mocks-http/pull/278/files#diff-1154dda4bd1664cbbc26d38ef62198bc2de555888999ca7b906ffdbb48c93d02R1180-R1192) for how to use the new event.