### PR TITLE
fix: return empty string when send was called with undefined

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -165,7 +165,7 @@ function createResponse(options = {}) {
                     _data = data;
                 }
             } else {
-                _data += data;
+                _data += data || '';
             }
         };
 

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1364,6 +1364,11 @@ describe('mockResponse', () => {
                 expect(response._getData()).to.equal('');
             });
 
+            it('should return empty string when sent data is undefined', () => {
+                response.send(undefined);
+                expect(response._getData()).to.equal('');
+            });
+
             it('should return sent data', () => {
                 response.send('data');
                 expect(response._getData()).to.equal('data');


### PR DESCRIPTION
Currently, if the `send` method is explicitly called with `undefined`, it returns the string `undefined`, instead of the expected empty string.