### PR TITLE
add to write and end support of TypedArray

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -31,6 +31,8 @@ let EventEmitter = require('./mockEventEmitter');
 const http = require('./node/http');
 const utils = require('./utils');
 
+const TypedArray = Object.getPrototypeOf(Uint8Array);
+
 function createResponse(options = {}) {
     let _endCalled = false;
     let _data = '';
@@ -352,6 +354,8 @@ function createResponse(options = {}) {
         if (data instanceof Buffer) {
             _chunks.push(data);
             _size += data.length;
+        } else if (data instanceof TypedArray) {
+            _data += new TextDecoder(encoding).decode(data);
         } else {
             _data += data;
         }
@@ -428,6 +432,8 @@ function createResponse(options = {}) {
             if (args.data instanceof Buffer) {
                 _chunks.push(args.data);
                 _size += args.data.length;
+            } else if (args.data instanceof TypedArray) {
+                _data += new TextDecoder(args.encoding).decode(args.data);
             } else {
                 _data += args.data;
             }

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -1242,6 +1242,14 @@ describe('mockResponse', () => {
             expect(response._getData()).to.equal(payload1 + payload2);
         });
 
+        it('should accept Uint8Array through write() and end() and concatenate them in _data', () => {
+            const payload1 = 'payload1';
+            const payload2 = 'payload2';
+            response.write(new TextEncoder().encode(payload1));
+            response.end(new TextEncoder().encode(payload2));
+            expect(response._getData()).to.equal(payload1 + payload2);
+        });
+
         it('should accept buffers through write() and end() and concatenate them in _buffer', () => {
             const payload1 = 'payload1';
             const payload2 = 'payload2';


### PR DESCRIPTION
Without this changes I got:

```
 AssertionError: expected '112,97,121,108,111,97,100,49112,97,12…' to equal 'payload1payload2'
      + expected - actual

      -112,97,121,108,111,97,100,49112,97,121,108,111,97,100,49
      +payload1payload2
```

It's broke HTML when use React's streaming API - _getData() returns numbers instead of valid HTML