### PR TITLE
Add appendHeader to MockResponse

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -636,7 +636,7 @@ function createResponse(options = {}) {
      *
      *   Append a header by name. If a header already exists, the new value is appended to the existing header.
      */
-    mockResponse.appendHeader = function setHeader(name, value) {
+    mockResponse.appendHeader = function appendHeader(name, value) {
         mockResponse.append(name, value);
         return this;
     };

--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -632,6 +632,16 @@ function createResponse(options = {}) {
     };
 
     /**
+     * Function: appendHeader
+     *
+     *   Append a header by name. If a header already exists, the new value is appended to the existing header.
+     */
+    mockResponse.appendHeader = function setHeader(name, value) {
+        mockResponse.append(name, value);
+        return this;
+    };
+
+    /**
      * Function: removeHeader
      *
      *   Removes an HTTP header by name.

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -85,6 +85,9 @@ describe('mockResponse', () => {
             expect(response).to.have.property('setHeader');
             expect(response.setHeader).to.be.a('function');
 
+            expect(response).to.have.property('appendHeader');
+            expect(response.appendHeader).to.be.a('function');
+
             expect(response).to.have.property('removeHeader');
             expect(response.removeHeader).to.be.a('function');
 
@@ -924,8 +927,8 @@ describe('mockResponse', () => {
         });
     });
 
-    // TODO: fix in 2.0; methods should be inherited from Node OutogingMessage
-    describe('Node OutogingMessage methods', () => {
+    // TODO: fix in 2.0; methods should be inherited from Node OutgoingMessage
+    describe('Node OutgoingMessage methods', () => {
         describe('.setHeader()', () => {
             let response;
 
@@ -948,6 +951,24 @@ describe('mockResponse', () => {
 
             it('should return this', () => {
                 expect(response.setHeader('name', 'value')).to.equal(response);
+            });
+        });
+
+        describe('.appendHeader()', () => {
+            let response;
+
+            beforeEach(() => {
+                response = mockResponse.createResponse();
+            });
+
+            afterEach(() => {
+                response = null;
+            });
+
+            it('should concatenate header values, when called twice with same name', () => {
+                response.appendHeader('name', 'value 1');
+                response.appendHeader('name', 'value 2');
+                expect(response.getHeader('name')).to.eql(['value 1', 'value 2']);
             });
         });
 


### PR DESCRIPTION
Mocking code that uses `res.appendHeader` currently fails, since it's not part of `MockResponse`.

`appendHeader` is part of Node since  v18.3.0, v16.17.0