### PR TITLE
Moving types to `peerDependencies` and allowing express 5

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ This project is available as a
 [NPM package][npm-url].
 
 ```bash
-$ npm install node-mocks-http @types/node @types/express --save-dev
+$ npm install node-mocks-http --save-dev
+$ npm install @types/node @types/express --save-dev # when using TypeScript
 ```
 
 or
 
 ```bash
-$ yarn add node-mocks-http @types/node @types/express --dev
+$ yarn add node-mocks-http --dev
+$ yarn add @types/node @types/express --dev # when using TypeScript
 ```
 
 After installing the package include the following in your test files:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This project is available as a
 [NPM package][npm-url].
 
 ```bash
-$ npm install node-mocks-http --save-dev
+$ npm install node-mocks-http @types/node @types/express --save-dev
 ```
 
 or
 
 ```bash
-$ yarn add node-mocks-http --dev
+$ yarn add node-mocks-http @types/node @types/express --dev
 ```
 
 After installing the package include the following in your test files:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,9 @@
   "packages": {
     "": {
       "name": "node-mocks-http",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@types/express": "^4.17.21",
-        "@types/node": "*",
         "accepts": "^1.3.7",
         "content-disposition": "^0.5.3",
         "depd": "^1.1.0",
@@ -44,6 +42,10 @@
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -754,6 +756,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -769,6 +772,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -793,6 +797,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -804,6 +809,7 @@
       "version": "4.17.33",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
       "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -825,7 +831,8 @@
     "node_modules/@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "peer": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -843,6 +850,7 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
       "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.11.1"
       }
@@ -856,12 +864,14 @@
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "peer": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -873,6 +883,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
       "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+      "peer": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -5937,7 +5948,8 @@
     "node_modules/undici-types": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
-      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ=="
+      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==",
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -6762,6 +6774,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "peer": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -6777,6 +6790,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "peer": true,
       "requires": {
         "@types/node": "*"
       }
@@ -6801,6 +6815,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
       "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "peer": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -6812,6 +6827,7 @@
       "version": "4.17.33",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
       "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "peer": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -6833,7 +6849,8 @@
     "@types/mime": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "peer": true
     },
     "@types/minimist": {
       "version": "1.2.5",
@@ -6851,6 +6868,7 @@
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.0.0.tgz",
       "integrity": "sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==",
+      "peer": true,
       "requires": {
         "undici-types": "~6.11.1"
       }
@@ -6864,12 +6882,14 @@
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "peer": true
     },
     "@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "peer": true
     },
     "@types/semver": {
       "version": "7.5.6",
@@ -6881,6 +6901,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
       "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+      "peer": true,
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -10706,7 +10727,8 @@
     "undici-types": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.11.1.tgz",
-      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ=="
+      "integrity": "sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==",
+      "peer": true
     },
     "update-browserslist-db": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@types/express": "^4.17.21",
-    "@types/node": "*",
     "accepts": "^1.3.7",
     "content-disposition": "^0.5.3",
     "depd": "^1.1.0",
@@ -58,6 +56,10 @@
     "parseurl": "^1.3.3",
     "range-parser": "^1.2.0",
     "type-is": "^1.6.18"
+  },
+  "peerDependencies": {
+    "@types/express": "^4.17.21 || ^5.0.0",
+    "@types/node": "*"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,14 @@
     "@types/express": "^4.17.21 || ^5.0.0",
     "@types/node": "*"
   },
+  "peerDependenciesMeta": {
+    "@types/express": {
+      "optional": true
+    },
+    "@types/node": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/chai": "^4.3.11",
     "@types/mocha": "^10.0.6",


### PR DESCRIPTION
Fixes #307 
Alternative implementation.

- Moved `@types/express` and `@types/node` (as requested) to `peerDependencies`
- Marked those peer dependencies as optional — only needed for those using TypeScript
- Allowed v5 of `@types/express`
- Added testing against latest Node 22