### PR TITLE
fix(mockResponse): writeHead() sets headersSent.

### DIFF
--- a/lib/mockResponse.js
+++ b/lib/mockResponse.js
@@ -141,6 +141,7 @@ function createResponse(options = {}) {
             Object.assign(mockResponse._headers, utils.convertKeysToLowerCase(headers));
         }
 
+        this.headersSent = true;
         return this;
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "node-mocks-http",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "accepts": "^1.3.7",

--- a/test/lib/mockResponse.spec.js
+++ b/test/lib/mockResponse.spec.js
@@ -870,10 +870,8 @@ describe('mockResponse', () => {
 
             it('updates the headersSent property of the response', () => {
                 const headers = { 'x-header': 'test llama' };
-                response.writeHead(400, headers);
-                // headers are only sent by node with first body byte
                 expect(response.headersSent).to.equal(false);
-                response.write('foo');
+                response.writeHead(400, headers);
                 expect(response.headersSent).to.equal(true);
                 // further updates to headers shouldn't really be reflected in mock headers
                 // since these would be transmitted as part of the body (probably breaking chunked encoding)


### PR DESCRIPTION
Fixes #312 

According to [documentation](https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers) and my debugging findings `writeHead()`:

> Sends a response header to the request. 

Meaning that it does actually set `headersSent` property to `true`.

This PR implements it and updates the test having wrong implication.